### PR TITLE
Fix console browser warning cookie

### DIFF
--- a/js/cornify.js
+++ b/js/cornify.js
@@ -191,7 +191,7 @@ var cornify_setcookie = function(name, value, days) {
     var d = new Date();
     d.setTime(d.getTime()+(days*24*60*60*1000));
     var expires = "expires="+d.toGMTString();
-    document.cookie = name + "=" + value + "; " + expires + "SameSite=None; Secure";
+    document.cookie = name + "=" + value + "; " + expires + "; SameSite=None; Secure";
 };
 
 var cornify_getcookie = function(cname) {

--- a/js/cornify.js
+++ b/js/cornify.js
@@ -191,7 +191,7 @@ var cornify_setcookie = function(name, value, days) {
     var d = new Date();
     d.setTime(d.getTime()+(days*24*60*60*1000));
     var expires = "expires="+d.toGMTString();
-    document.cookie = name + "=" + value + "; " + expires;
+    document.cookie = name + "=" + value + "; " + expires + "SameSite=None; Secure";
 };
 
 var cornify_getcookie = function(cname) {


### PR DESCRIPTION
I fixed the console browser warning below setting `; SameSite=none; Secure` in the function `cornify_setcookie()`.

> Some cookies are misusing the “sameSite“ attribute, so it won’t work as expected.
Cookie “myCookie” rejected because it has the “sameSite=none” attribute but is missing the “secure” attribute.
