### PR TITLE
Fixed removing of unicorns to remove all

### DIFF
--- a/js/cornify.js
+++ b/js/cornify.js
@@ -255,7 +255,7 @@ var cornify_replace = function() {
 var cornify_click_cupcake_button = function() {
     var doc = document;
 
-    var corns = doc.getElementsByClassName('__cornify_unicorn');
+    var corns = doc.querySelectorAll('.__cornify_unicorn');
     if(corns) {
         for(var i=0; i<corns.length; i++) {
             corns[i].parentNode.removeChild(corns[i]);


### PR DESCRIPTION
Using `getElementsByClassName` returns a live HTMLCollection.   When doing the `for` loop, the `corns` list was shrinking by reference thus not all of the unicorns were removed.   Using a plain `querySelectorAll` returns static node list.

https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll